### PR TITLE
renovate: Turn the dashboard on and group weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "automerge": false
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "dependencyDashboard": true,
-  "automerge": false
+  "automerge": false,
+  "packageRules": [
+    {
+      "description": "Group patch and minor updates into one weekly pull request. This is the rule that keeps the GitLab gitops queue at two open merge requests instead of two hundred.",
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "weekly patch and minor updates",
+      "schedule": ["before 6am on monday"]
+    },
+    {
+      "description": "Majors always get their own pull request with a label, never grouped. They are the ones worth reading.",
+      "matchUpdateTypes": ["major"],
+      "labels": ["renovate/major-update"]
+    }
+  ]
 }


### PR DESCRIPTION
## What

Add `renovate.json`:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["config:recommended"],
  "dependencyDashboard": true,
  "automerge": false
}
```

## Why

Card 2341 and card 2343 on board 18 ([USL] CIO). This repository had no Renovate config, so it ran on the app defaults and Renovate opened no Dependency Dashboard issue.

Two things follow from that. The queue Renovate holds back is written down nowhere. And a repository sitting at the concurrent-pull-request cap of 10 looks the same whether it holds no more bumps or two hundred. You cannot size the work, so you cannot decide whether to do it.

`config:recommended` is what the app already applied. The file makes it explicit and turns the dashboard on. `automerge: false` states the current behaviour rather than changing it.


## What I did not do, and why

The card asks for a public `unstaticlabs/renovate-config` repository holding a shared preset, with each repository pointing at it through `extends: ["local>unstaticlabs/renovate-config"]`.

I did not create it. Creating a public repository in the organisation is not something I do without you asking for it directly, and it cannot go through a pull request, so you would have no review before it exists.

The file above is self-contained and reaches the same end. When you want the shared preset, create the repository with that one `default.json`, then replace the four lines here with the one-line `extends`. Nothing in this pull request gets in the way.

I also left the title at Renovate's default, `Dependency Dashboard`, instead of the card's `Renovate dependency dashboard`. The card's own acceptance query searches for `Dependency Dashboard in:title`, and every Renovate user looks for that name.


## The second commit: weekly grouping

Card 2343 asks for one more thing, and it is the higher-value half.

`unstaticlabs/infra/gitops` on GitLab holds **two** open Renovate merge requests. The GitHub fleet holds **217**, and 16 repositories sit pinned at the concurrent-pull-request cap of 10. The difference is one rule, which that repository has and this one does not:

```json
{
  "matchUpdateTypes": ["patch", "minor"],
  "groupName": "weekly patch and minor updates",
  "schedule": ["before 6am on monday"]
}
```

So patch and minor bumps arrive as one pull request each Monday. Majors keep their own pull request and a label, because those are the ones worth reading.

The whole file, after both commits:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["config:recommended"],
  "dependencyDashboard": true,
  "automerge": false,
  "packageRules": [
    {
      "description": "Group patch and minor updates into one weekly pull request. ...",
      "matchUpdateTypes": ["patch", "minor"],
      "groupName": "weekly patch and minor updates",
      "schedule": ["before 6am on monday"]
    },
    {
      "description": "Majors always get their own pull request with a label, never grouped. ...",
      "matchUpdateTypes": ["major"],
      "labels": ["renovate/major-update"]
    }
  ]
}
```

It validates against the current Renovate:

```
$ npx --package renovate@44.48.0 -- renovate-config-validator renovate.json
 INFO: Config validated successfully against 1 file(s)
```

## Three card premises that are wrong

1. The card says only `rogerxaic/nomad_gitops` carries a `renovate.json`. Two more do: `unstaticlabs/goodboysclub_medusa_backend` and `unstaticlabs/goodboysclub_medusa_storefront`. Both hold hand-written package rules. I did not replace them; each gets a one-key addition instead.
2. The card says no repository has a Dependency Dashboard issue. `rogerxaic/nomad_gitops` has one, issue #20. It is the one repository whose config extends `config:recommended`, and `config:recommended` already includes `:dependencyDashboard`.
3. The card's acceptance query uses `gh issue list --author app/renovate`. That filter returns nothing for issues even when the dashboard exists — it is a broken query, not evidence of absence. Read the titles instead.

## Issues must be on

Four repositories have issues disabled, so no dashboard can appear there until you turn issues on: `smashchats/smash-node-lib`, `smashchats/smash-simple-nab`, `unstaticlabs/smash-node-lib` and `unstaticlabs/unstaticlabs.com`. The card named only the first. This pull request still lands the config, so the dashboard appears the moment you flip the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
